### PR TITLE
Add function prototype to get rid of XCode warning

### DIFF
--- a/ext/PhoneNumberFormatter/PhoneNumberFormatter.m
+++ b/ext/PhoneNumberFormatter/PhoneNumberFormatter.m
@@ -143,8 +143,8 @@
 
 @end
 
-void
-Init_PhoneNumberFormatter(void)
+void Init_PhoneNumberFormatter(void);
+void Init_PhoneNumberFormatter(void)
 {
   // Do nothing. This function is required by the MacRuby runtime when this
   // file is compiled as a C extension bundle.


### PR DESCRIPTION
XCode doesn't like the Init_PhoneNumberFormatter method used for MacRuby without declaring a prototype.
