### PR TITLE
Modified the formatting behavior to be less aggressive on input strings that begin with 1.

### DIFF
--- a/ECPhoneNumberFormatter/ECPhoneNumberFormatter.m
+++ b/ECPhoneNumberFormatter/ECPhoneNumberFormatter.m
@@ -26,7 +26,6 @@
 @interface ECPhoneNumberFormatter()
 - (NSString *)parseString:(NSString *)input;
 - (NSString *)parseStringStartingWithOne:(NSString *)input;
-- (NSString *)parsePartialStringStartingWithOne:(NSString *)input;
 - (NSString *)parseLastSevenDigits:(NSString *)basicNumber;
 
 - (NSString *)stripNonDigits:(NSString *)input;
@@ -43,14 +42,14 @@
 - (NSString *)stringForObjectValue:(id)anObject {
     if (![anObject isKindOfClass:[NSString class]]) return nil;
     if ([anObject length] < 1) return nil;
-
+    
     NSCharacterSet *doNotWant = [[NSCharacterSet decimalDigitCharacterSet] invertedSet];
     NSString *unformatted = [[(NSString *)anObject componentsSeparatedByCharactersInSet: doNotWant] componentsJoinedByString: @""];
     if (unformatted.length == 0) return nil;
-
+    
     NSString *firstNumber = [unformatted substringToIndex:1],
     *output;
-
+    
     if ([firstNumber isEqualToString:@"1"]) {
         output = [self parseStringStartingWithOne:unformatted];
     } else {
@@ -70,7 +69,7 @@
     NSString *formattedNew      = [self stringForObjectValue:proposedNewString];
     NSUInteger formattedLocationNew = 0;
     NSUInteger lengthAdded          = 0;
-
+    
     if (formattedOld.length > proposedNewString.length) { // removing characters
         lengthAdded = -(origSelRange.location - (*proposedSelRangePtr).location);
     } else if (formattedOld.length < proposedNewString.length) { // adding characters
@@ -78,12 +77,12 @@
     } else { // replace characters
         lengthAdded = origSelRange.length;
     }
-
+    
     formattedLocationNew = [self formattedNewLocationFromOldFormatted:formattedOld formattedNew:formattedNew formattedOldLocation:origSelRange.location lengthAdded:lengthAdded];
-
+    
     *partialStringPtr = formattedNew;
     *proposedSelRangePtr = NSMakeRange(formattedLocationNew, (*proposedSelRangePtr).length);
-
+    
     return NO;
 }
 
@@ -101,23 +100,23 @@
     NSUInteger unformattedLocationOld = [[self stripNonDigits:[formattedOld substringToIndex:formattedOldLocation]] length];
     NSUInteger unformattedLocationNew = unformattedLocationOld + lengthAdded;
     NSUInteger formattedLocationNew   = 0;
-
+    
     while (unformattedLocationNew > 0 && formattedLocationNew < formattedNew.length) {
         unichar currentCharacter = [formattedNew characterAtIndex:formattedLocationNew];
         if ([[NSCharacterSet decimalDigitCharacterSet] characterIsMember:currentCharacter]) {
             unformattedLocationNew--;
         }
-
+        
         formattedLocationNew++;
     }
-
+    
     return formattedLocationNew;
 }
 
 - (NSString *)parseLastSevenDigits:(NSString *)input {
     NSString *output;
     NSMutableString *obj = [NSMutableString stringWithString:input];
-
+    
     if ([obj length] >= 4 && [obj length] <= 7) {
         [obj insertString:@"-" atIndex:3];
         output = obj;
@@ -131,7 +130,7 @@
     NSMutableString *obj = [NSMutableString stringWithString:input];
     NSString *output;
     NSUInteger len = input.length;
-
+    
     if (len >= 8 && len <= 10) {
         NSString *areaCode  = [obj substringToIndex:3];
         NSString *lastSeven = [self parseLastSevenDigits:[obj substringFromIndex:3]];
@@ -144,30 +143,21 @@
     return output;
 }
 
-- (NSString *)parsePartialStringStartingWithOne:(NSString *)input {
-    NSMutableString *partialAreaCode = [NSMutableString stringWithString:[input substringFromIndex:1]];
-    NSUInteger numSpaces = 3 - partialAreaCode.length, i;
-
-    for (i = 0; i < numSpaces; i++) {
-        [partialAreaCode appendString:@" "];
-    }
-    return [NSString stringWithFormat:@"1 (%@)", partialAreaCode];
-}
 
 - (NSString *)parseStringStartingWithOne:(NSString *)input {
     NSUInteger len = input.length;
     NSString *output;
-
+    
     if (len == 1 || len >= 12) {
         output = input;
     } else if (len > 4) {
-        NSString *firstPart  = [self parsePartialStringStartingWithOne:[input substringToIndex:4]];
+        NSString *firstPart  = [input substringWithRange:NSMakeRange(1, 3)];
         NSString *secondPart = [self parseLastSevenDigits:[input substringFromIndex:4]];
-        output = [NSString stringWithFormat:@"%@ %@", firstPart, secondPart];
+        output = [NSString stringWithFormat:@"1 (%@) %@", firstPart, secondPart];
     } else {
-        output = [NSString stringWithFormat:@"%@", [self parsePartialStringStartingWithOne:input]];
+        output = input;
     }
-
+    
     return output;
 }
 

--- a/Tests/ECPhoneNumberFormatter/ECPhoneNumberFormatterSpecs/ECPhoneNumberFormatterSpec.m
+++ b/Tests/ECPhoneNumberFormatter/ECPhoneNumberFormatterSpecs/ECPhoneNumberFormatterSpec.m
@@ -71,16 +71,16 @@ describe(@"ECPhoneNumberFormatter", ^{
         });
 
         describe(@"starting with a 1", ^{
-            it(@"returns 1 (2  ) for 12", ^{
-                [[[phoneNumberFormatter stringForObjectValue:@"12"] should] equal:@"1 (2  )"];
+            it(@"returns 12 for 12", ^{
+                [[[phoneNumberFormatter stringForObjectValue:@"12"] should] equal:@"12"];
             });
 
-            it(@"returns 1 (23 ) for 123", ^{
-                [[[phoneNumberFormatter stringForObjectValue:@"123"] should] equal:@"1 (23 )"];
+            it(@"returns 123 for 123", ^{
+                [[[phoneNumberFormatter stringForObjectValue:@"123"] should] equal:@"123"];
             });
 
-            it(@"returns 1 (234) for 1234", ^{
-                [[[phoneNumberFormatter stringForObjectValue:@"1234"] should] equal:@"1 (234)"];
+            it(@"returns 1234 for 1234", ^{
+                [[[phoneNumberFormatter stringForObjectValue:@"1234"] should] equal:@"1234"];
             });
 
             it(@"returns 1 (234) 5 for 12345", ^{


### PR DESCRIPTION
Modified the formatting behavior to be less aggressive on input strings that begin with "1". Previously, the formatter would insert the parenthesis around the area code once the string beginning with "1" had a length of 2. Now, the parenthesis are inserted around the area code only once the length of the string beginning with "1" is 5. Additionally, this commit modifies the tests project to accept this behavior. All other unrelated tests pass.

This causes better behavior when formatting phone number strings as they are typed. If you set up a UITextField to format the number after each time the string changes. It becomes impossible to delete the string "1 (234)" because the formatter will reinsert the deleted ')'. See the example below.

![before](https://cloud.githubusercontent.com/assets/1464005/4292889/3e8356b6-3dd1-11e4-88eb-b611ef673ef8.gif) ____ ![after](https://cloud.githubusercontent.com/assets/1464005/4292891/42776f64-3dd1-11e4-993a-99d5d88d910e.gif)
